### PR TITLE
Fixes redundant math when initializing constant

### DIFF
--- a/index.js
+++ b/index.js
@@ -393,7 +393,7 @@ client.on('message', message => {
 
     const now = Date.now();
     const timestamps = cooldowns.get('lastMessage');
-    const cooldownAmount = 60 * 1000;
+    const cooldownAmount = 60_000;
 
     if (timestamps.has(message.author.id)) {
         const expirationTime = timestamps.get(message.author.id) + cooldownAmount;


### PR DESCRIPTION
Currently, initializing constant cooldownAmount is set to 60 * 1000. The goal of this pull request is to fix this redundant math by setting it to 60000, and also making it easy to read in the process (60_000).