### PR TITLE
Add NaN check

### DIFF
--- a/commands/hotel.js
+++ b/commands/hotel.js
@@ -287,7 +287,7 @@ module.exports = {
                         break;
                     default:
                         if (args.length == 1) {
-                            if (!isNaN(args[0])) {
+                            if (!isNaN(args[0]) || args[0].toLowerCase() === "nan") {
                                 const getFloor = parseInt(args[0]);
                                 const floorData = await dbInstance.collection("hotel").findOne({ floor: getFloor });
                                 if (floorData != null) {


### PR DESCRIPTION
This change makes !hotel NaN (or any capitalization of NaN) show floor NaN, so that my floor NaN is still viewable

Other NaN values like "foo" will not bypass this change, only "NaN"