### PR TITLE
Change time comparison from milliseconds to Days

### DIFF
--- a/commands/daily.js
+++ b/commands/daily.js
@@ -3,6 +3,7 @@ const { mongodbase, currentdb } = require('../config.json');
 module.exports = {
 	name: 'daily',
 	description: 'Gets daily credits.',
+	aliases: ['redeem'],
 	guildOnly: true,
 	category: "eco",
 	execute(message, args) {

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -21,10 +21,10 @@ module.exports = {
 			} else {
 				const two = user.dailytime
 				const dateNow = new Date();
-				var millisecondsPerDay = 1000 * 60 * 60 * 12;
+				var millisecondsPerDay = 43_200_000;
 				var millisBetween = dateNow - two;
-				var days = parseInt(millisBetween / millisecondsPerDay);
-				if (days > .5) {
+				var days = parseInt(millisecondsPerDay - millisBetween);
+				if (days = 0) {
 					let newbalance = user.balance + 1000;
 					let newTotal = user.totalCredits + 1000;
 					const myobj = { id: message.author.id };

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -21,14 +21,14 @@ module.exports = {
 			} else {
 				const two = user.dailytime
 				const dateNow = new Date();
-				var millisecondsPerDay = 43_200_000;
-				var millisBetween = dateNow - two;
-				var days = parseInt(millisecondsPerDay - millisBetween);
-				if (days = 0) {
+				// var millisecondsPerDay = 43_200_000;
+				// var millisBetween = dateNow - two;
+				var days = daysNow.getUTCDay();
+				if (days != two) {
 					let newbalance = user.balance + 1000;
 					let newTotal = user.totalCredits + 1000;
 					const myobj = { id: message.author.id };
-					const newvalues = { $set: { name: message.author.tag, balance: newbalance, dailytime: dateNow, totalCredits: newTotal } };
+					const newvalues = { $set: { name: message.author.tag, balance: newbalance, dailytime: dateNow.getUTCDay(), totalCredits: newTotal } };
 					dbInstance.collection("users").updateOne(myobj, newvalues, function (err, res) {
 						if (err) throw err;
 						message.reply(`\`1,000\` daily credits redeemed. Your new balance is \`${newbalance.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")}\`.`)

--- a/index.js
+++ b/index.js
@@ -393,7 +393,7 @@ client.on('message', message => {
 
     const now = Date.now();
     const timestamps = cooldowns.get('lastMessage');
-    const cooldownAmount = 60 * 1000;
+    const cooldownAmount = 60_000;
 
     if (timestamps.has(message.author.id)) {
         const expirationTime = timestamps.get(message.author.id) + cooldownAmount;


### PR DESCRIPTION
Using this would mean users could get credits as soon as it turns to the next day rather than waiting for an exact time.