### PR TITLE
Change daily.js date checking system from a millisecond based system to a UTC date based system

### DIFF
--- a/commands/daily.js
+++ b/commands/daily.js
@@ -30,7 +30,7 @@ module.exports = {
 					let newbalance = user.balance + 1000;
 					let newTotal = user.totalCredits + 1000;
 					const myobj = { id: message.author.id };
-					const newvalues = { $set: { name: message.author.tag, balance: newbalance, dailytime: dateNow.getUTCDate(), totalCredits: newTotal } };
+					const newvalues = { $set: { name: message.author.tag, balance: newbalance, dailytime: [dateNow.getUTCDate(), dateNow.getUTCMonth], totalCredits: newTotal } };
 					dbInstance.collection("users").updateOne(myobj, newvalues, function (err, res) {
 						if (err) throw err;
 						message.reply(`\`1,000\` daily credits redeemed. Your new balance is \`${newbalance.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")}\`.`)

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -13,7 +13,7 @@ module.exports = {
 			const user = await dbInstance.collection("users").findOne({ id: message.author.id });
 			if (user == null) {
 				const dateNow = new Date();
-				var myobj = { id: message.author.id, name: message.author.tag, balance: 1000, dailytime: dateNow, totalCredits: 1000, color: "#000000", slotsPlays: 0, blackjackPlays: 0, lastWin: 0 };
+				var myobj = { id: message.author.id, name: message.author.tag, balance: 1000, dailytime: [dateNow.getUTCDate(), dateNow.getUTCMonth()], totalCredits: 1000, color: "#000000", slotsPlays: 0, blackjackPlays: 0, lastWin: 0 };
 				dbInstance.collection("users").insertOne(myobj, function (err, res) {
 					if (err) throw err;
 					message.reply(`account created. \`1,000\` credits were added to your balance.`)
@@ -30,7 +30,7 @@ module.exports = {
 					let newbalance = user.balance + 1000;
 					let newTotal = user.totalCredits + 1000;
 					const myobj = { id: message.author.id };
-					const newvalues = { $set: { name: message.author.tag, balance: newbalance, dailytime: [dateNow.getUTCDate(), dateNow.getUTCMonth], totalCredits: newTotal } };
+					const newvalues = { $set: { name: message.author.tag, balance: newbalance, dailytime: [dateNow.getUTCDate(), dateNow.getUTCMonth()], totalCredits: newTotal } };
 					dbInstance.collection("users").updateOne(myobj, newvalues, function (err, res) {
 						if (err) throw err;
 						message.reply(`\`1,000\` daily credits redeemed. Your new balance is \`${newbalance.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")}\`.`)

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -24,12 +24,13 @@ module.exports = {
 				const dateNow = new Date();
 				// var millisecondsPerDay = 43_200_000;
 				// var millisBetween = dateNow - two;
-				var days = daysNow.getUTCDay();
-				if (days != two) {
+				var date = [dateNow.getUTCDate(), dateNow.getUTCMonth()];
+                                // var month = dateNow.getUTCMonth();
+				if (date[0] != two[0] || date[1] != two[0]) {
 					let newbalance = user.balance + 1000;
 					let newTotal = user.totalCredits + 1000;
 					const myobj = { id: message.author.id };
-					const newvalues = { $set: { name: message.author.tag, balance: newbalance, dailytime: dateNow.getUTCDay(), totalCredits: newTotal } };
+					const newvalues = { $set: { name: message.author.tag, balance: newbalance, dailytime: dateNow.getUTCDate(), totalCredits: newTotal } };
 					dbInstance.collection("users").updateOne(myobj, newvalues, function (err, res) {
 						if (err) throw err;
 						message.reply(`\`1,000\` daily credits redeemed. Your new balance is \`${newbalance.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")}\`.`)

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -3,6 +3,7 @@ const { mongodbase, currentdb } = require('../config.json');
 module.exports = {
 	name: 'daily',
 	description: 'Gets daily credits.',
+	aliases: ['redeem'],
 	guildOnly: true,
 	category: "eco",
 	execute(message, args) {

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -21,10 +21,10 @@ module.exports = {
 			} else {
 				const two = user.dailytime
 				const dateNow = new Date();
-				var millisecondsPerDay = 1000 * 60 * 60 * 12;
+				var millisecondsPerDay = 43_200_000;
 				var millisBetween = dateNow - two;
-				var days = parseInt(millisBetween / millisecondsPerDay);
-				if (days > .5) {
+				var days = parseInt(millisecondsPerDay - millisBetween);
+				if (days = 0) {
 					let newbalance = user.balance + 1000;
 					let newTotal = user.totalCredits + 1000;
 					const myobj = { id: message.author.id };

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -21,14 +21,14 @@ module.exports = {
 			} else {
 				const two = user.dailytime
 				const dateNow = new Date();
-				var millisecondsPerDay = 43_200_000;
-				var millisBetween = dateNow - two;
-				var days = parseInt(millisecondsPerDay - millisBetween);
-				if (days = 0) {
+				// var millisecondsPerDay = 43_200_000;
+				// var millisBetween = dateNow - two;
+				var days = daysNow.getUTCDay();
+				if (days != two) {
 					let newbalance = user.balance + 1000;
 					let newTotal = user.totalCredits + 1000;
 					const myobj = { id: message.author.id };
-					const newvalues = { $set: { name: message.author.tag, balance: newbalance, dailytime: dateNow, totalCredits: newTotal } };
+					const newvalues = { $set: { name: message.author.tag, balance: newbalance, dailytime: dateNow.getUTCDay(), totalCredits: newTotal } };
 					dbInstance.collection("users").updateOne(myobj, newvalues, function (err, res) {
 						if (err) throw err;
 						message.reply(`\`1,000\` daily credits redeemed. Your new balance is \`${newbalance.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")}\`.`)

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -22,10 +22,10 @@ module.exports = {
 			} else {
 				const two = user.dailytime
 				const dateNow = new Date();
-				// var millisecondsPerDay = 43_200_000;
+				// var millisecondsPerDay = 43_200_000; // remove ms checking in favour for day checking (avoids having to wait exactly 24h)
 				// var millisBetween = dateNow - two;
-				var date = [dateNow.getUTCDate(), dateNow.getUTCMonth()];
-                                // var month = dateNow.getUTCMonth();
+				var date = [dateNow.getUTCDate(), dateNow.getUTCMonth()]; // check time + month avoids issues with redeeming on the same day next month.
+                                // var month = dateNow.getUTCMonth();                    // redeeming in exactly one year is unlikely
 				if (date[0] != two[0] || date[1] != two[1]) {
 					let newbalance = user.balance + 1000;
 					let newTotal = user.totalCredits + 1000;

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -26,7 +26,7 @@ module.exports = {
 				// var millisBetween = dateNow - two;
 				var date = [dateNow.getUTCDate(), dateNow.getUTCMonth()];
                                 // var month = dateNow.getUTCMonth();
-				if (date[0] != two[0] || date[1] != two[0]) {
+				if (date[0] != two[0] || date[1] != two[1]) {
 					let newbalance = user.balance + 1000;
 					let newTotal = user.totalCredits + 1000;
 					const myobj = { id: message.author.id };

--- a/index.js
+++ b/index.js
@@ -393,7 +393,7 @@ client.on('message', message => {
 
     const now = Date.now();
     const timestamps = cooldowns.get('lastMessage');
-    const cooldownAmount = 60 * 1000;
+    const cooldownAmount = 60_000;
 
     if (timestamps.has(message.author.id)) {
         const expirationTime = timestamps.get(message.author.id) + cooldownAmount;


### PR DESCRIPTION
This is a revision of PR #8. This fixes some major flaws with the date check, as well as code optimization.

The goal of this PR is to change from a system that requires you to wait exactly 24h in favour for a system that allows you to wait until the next UTC day. It also grabs the month to assure that there would be no conflicts redeeming in exactly one month. Year is not necessary as it is highly unlikely someone will wait exactly one year to redeem.

This PR is almost ready to merge into the master branch. The only thing that would need to be done to prepare for this is to allow the database to accept an array of Date for “dailytime”. If there is a flaw with this PR, please let me know and I will fix it.